### PR TITLE
cacheDom() needs to be called upon start

### DIFF
--- a/src/main/main.js
+++ b/src/main/main.js
@@ -1508,6 +1508,7 @@ export function start (){
         player[i].phys.face = 1;
         player[i].actionState = "WAIT";
     }
+    cacheDom();
     getKeyboardCookie();
     getTargetCookies();
     giveMedals();


### PR DESCRIPTION
to avoid dom elements to be undefined for later uses